### PR TITLE
[4.0] Change access to body of Response object

### DIFF
--- a/Tests/Stub/TestClient.php
+++ b/Tests/Stub/TestClient.php
@@ -32,7 +32,7 @@ class TestClient extends Client
     public function validateResponse($url, $response)
     {
         if ($response->getStatusCode() < 200 || $response->getStatusCode() > 399) {
-            throw new \DomainException($response->getBody()->getContents());
+            throw new \DomainException((string) $response->getBody());
         }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -179,7 +179,7 @@ abstract class Client
         // Make an OAuth request for the Request Token.
         $response = $this->oauthRequest($this->getOption('requestTokenURL'), 'POST', $parameters);
 
-        parse_str($response->getBody()->getContents(), $params);
+        parse_str((string) $response->getBody(), $params);
 
         if (strcmp($this->version, '1.0a') === 0 && strcmp($params['oauth_callback_confirmed'], 'true') !== 0) {
             throw new \DomainException('Bad request token!');
@@ -236,7 +236,7 @@ abstract class Client
         // Make an OAuth request for the Access Token.
         $response = $this->oauthRequest($this->getOption('accessTokenURL'), 'POST', $parameters);
 
-        parse_str($response->getBody()->getContents(), $params);
+        parse_str((string) $response->getBody(), $params);
 
         // Save the access token.
         $this->token = ['key' => $params['oauth_token'], 'secret' => $params['oauth_token_secret']];


### PR DESCRIPTION
### Summary of Changes
When converting the code to v4 of the Joomla HTTP package, the method `Response->getBody()->getContents()` was used to access the body of the response, which can be problematic, when the pointer of the internal stream is not set to the beginning. This PR changes the code to use the magic `__toString()` method of the `StreamInterface` instead.

### Testing Instructions
Codereview

### Documentation Changes Required
none